### PR TITLE
actions workflow: tests and build for PR

### DIFF
--- a/.github/workflows/pr_open.yml
+++ b/.github/workflows/pr_open.yml
@@ -1,0 +1,29 @@
+name: Test and Build
+
+# Controls when the action will run. Triggers the workflow on pull request on master
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-and-build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Install yarn dependencies
+      run: |
+        yarn install
+    # Run Tests
+    - name: Run tests
+      run: |
+        yarn test
+    # Build Android
+    - name: Build Android Release
+      run: |
+        cd android && chmod +x 'gradlew' && ./gradlew assembleRelease


### PR DESCRIPTION
Added Github actions workflow which will run tests and trigger a build when a PR is opened. If both jobs are successful, then its mostly good to merge the PR.

